### PR TITLE
changes for working properly with yaml.v3

### DIFF
--- a/internal/commands/from-json.go
+++ b/internal/commands/from-json.go
@@ -87,7 +87,7 @@ func (c *_FromJSONCommand) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	// Now check the type of object read from the JSON file.
-	if mapValue, ok := value.(map[interface{}]interface{}); ok {
+	if mapValue, ok := value.(map[string]interface{}); ok {
 		c.globalOpts.YamlFile().SetData(mapValue)
 		changed = true
 	} else if strMapValue, ok := value.(map[string]interface{}); ok {

--- a/internal/commands/set_test.go
+++ b/internal/commands/set_test.go
@@ -33,9 +33,9 @@ var _ = Describe("Set command scenarios", func() {
 a:
   b:
     c:
-    - value1
-    - value2
-    - value3  
+      - value1
+      - value2
+      - value3
 `)
 	var extraSetArrayKey = "a.b.c"
 	var extraSetArrayValueAsJSON = `["value1","value2","value3"]`

--- a/internal/commands/suite_test.go
+++ b/internal/commands/suite_test.go
@@ -50,10 +50,10 @@ It is not parsable as JSON either.
 // Sample yaml from: https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started/
 var _SampleYAML = strings.TrimSpace(`
 calling-birds:
-- huey
-- dewey
-- louie
-- fred
+  - huey
+  - dewey
+  - louie
+  - fred
 doe: a deer, a female deer
 french-hens: 3
 pi: 3.14159

--- a/internal/commands/to-json.go
+++ b/internal/commands/to-json.go
@@ -66,7 +66,7 @@ Note:
 }
 
 func (c *_ToJSONCommand) run(cmd *cobra.Command, args []string) (err error) {
-	if converted, mapData := c.globalOpts.YamlFile().Map(); converted {
+	if mapData := c.globalOpts.YamlFile().Data(); mapData != nil {
 		var bytes []byte
 
 		if bytes, err = marshalToJSON(mapData, c.pretty); err != nil {

--- a/pkg/yamldoc/errors.go
+++ b/pkg/yamldoc/errors.go
@@ -11,7 +11,17 @@ type wrongTypeError struct {
 }
 
 func (e *wrongTypeError) Error() string {
-	return fmt.Sprintf("Expected type '%s' but got '%s'", e.expectedType.String(), e.gotType.String())
+	var (
+		expectedType = "<NIL>"
+		gotType      = "<NIL>"
+	)
+	if e.expectedType != nil {
+		expectedType = e.expectedType.String()
+	}
+	if e.gotType != nil {
+		gotType = e.gotType.String()
+	}
+	return fmt.Sprintf("Expected type '%s' but got '%s'", expectedType, gotType)
 }
 
 // IsWrongTypeError - check if the error is a wrong type error.

--- a/pkg/yamldoc/examples_test.go
+++ b/pkg/yamldoc/examples_test.go
@@ -26,7 +26,7 @@ first:
 	// Read a value from the YAML file
 	var value string
 	if value, err = yamlDoc.GetString("first.second.third"); err != nil {
-		fmt.Printf("ERROR while reading value from yaml\n")
+		fmt.Printf("ERROR while reading value from yaml: %v\n", err.Error())
 		return
 	}
 
@@ -52,7 +52,7 @@ first:
 	// Read a value from the YAML file
 	var value string
 	if value, err = yamlDoc.GetString("first.second.third"); err != nil {
-		fmt.Printf("ERROR while reading value from yaml\n")
+		fmt.Printf("ERROR while reading value from yaml: %v\n", err.Error())
 		return
 	}
 
@@ -81,7 +81,7 @@ first:
 	// Read a value from the YAML file
 	var value string
 	if value, err = yamlDoc.GetString("first.second.third"); err != nil {
-		fmt.Printf("ERROR while reading value from yaml\n")
+		fmt.Printf("ERROR while reading value from yaml: %v\n", err.Error())
 		return
 	}
 

--- a/pkg/yamldoc/yamldoc_test.go
+++ b/pkg/yamldoc/yamldoc_test.go
@@ -143,24 +143,8 @@ func checkSampleYaml(yaml YamlDoc, yamlText string) {
 
 var _ = Describe("Yaml functions", func() {
 	var (
-		yaml     YamlDoc
-		yamlText = strings.TrimSpace(_SampleYaml)
-		yamlMap  = map[interface{}]interface{}{
-			"a": map[interface{}]interface{}{
-				"b": map[interface{}]interface{}{
-					"c": "value-c",
-				},
-				"custom": map[interface{}]interface{}{
-					"string-prop": "string-value",
-					"int-prop":    100,
-					"bool-prop":   true,
-				},
-				"d": map[interface{}]interface{}{
-					"e": false,
-					"f": 10,
-				},
-			},
-		}
+		yaml          YamlDoc
+		yamlText      = strings.TrimSpace(_SampleYaml)
 		yamlStringMap = map[string]interface{}{
 			"a": map[string]interface{}{
 				"b": map[string]interface{}{
@@ -222,23 +206,17 @@ var _ = Describe("Yaml functions", func() {
 		})
 		// Check the data in the yaml is the same as the map we initialized with
 		JustBeforeEach(func() {
-			yaml.SetData(yamlMap)
+			yaml.SetData(yamlStringMap)
 		})
 
 		It("is the same as the original map", func() {
-			Expect(reflect.DeepEqual(yamlMap, yaml.Data())).To(BeTrue())
+			Expect(reflect.DeepEqual(yamlStringMap, yaml.Data())).To(BeTrue())
 		})
 
 		It("Check sample yaml", func() {
 			checkSampleYaml(yaml, yamlText)
 		})
 
-		It("can convert to map[string]interface{}", func() {
-			// Get the data as a map[string]interface{} is the same as the one we initialized with
-			converted, strYamlMap := yaml.Map()
-			Expect(converted).To(BeTrue())
-			Expect(reflect.DeepEqual(strYamlMap, yamlStringMap)).To(BeTrue())
-		})
 		It("can read custom object", func() {
 			obj := newCustomStruct()
 			expectedObj := expectedCustomStruct()

--- a/pkg/yamlfile/examples_test.go
+++ b/pkg/yamlfile/examples_test.go
@@ -34,7 +34,7 @@ first:
 	} else if loaded {
 		var value string
 		if value, err = yamlFile.GetString("first.second.third"); err != nil {
-			fmt.Printf("ERROR while reading value from yaml\n")
+			fmt.Printf("ERROR while reading value from yaml: %v\n", err.Error())
 			return
 		}
 
@@ -69,7 +69,7 @@ first:
 	} else if loaded {
 		var value string
 		if value, err = yamlFile.GetString("first.second.third"); err != nil {
-			fmt.Printf("ERROR while reading value from yaml\n")
+			fmt.Printf("ERROR while reading value from yaml: %v\n", err.Error())
 			return
 		}
 

--- a/pkg/yamlfile/yaml-file_test.go
+++ b/pkg/yamlfile/yaml-file_test.go
@@ -24,18 +24,7 @@ a:
 )
 
 var (
-	yamlText = strings.TrimSpace(_SampleYaml)
-	yamlMap  = map[interface{}]interface{}{
-		"a": map[interface{}]interface{}{
-			"b": map[interface{}]interface{}{
-				"c": "value-c",
-			},
-			"d": map[interface{}]interface{}{
-				"e": false,
-				"f": 10,
-			},
-		},
-	}
+	yamlText      = strings.TrimSpace(_SampleYaml)
 	yamlStringMap = map[string]interface{}{
 		"a": map[string]interface{}{
 			"b": map[string]interface{}{
@@ -116,7 +105,7 @@ var _ = Describe("YamlFile functions", func() {
 			// It should not exist
 			Expect(yamlFile.Exists()).To(BeFalse())
 			// Set the data
-			yamlFile.SetData(yamlMap)
+			yamlFile.SetData(yamlStringMap)
 
 			checkText(yamlFile, yamlText)
 


### PR DESCRIPTION
After switching from `gopkg.in/yaml.v2` to `gopkg.in/yaml.v3` there were 2 changes that impacted both the tests and actual CLI and package code:
1. The default map type when parsing yaml files changed from `map[interface{}]interface{}` to `map[string]interface{}`
2. The default identation when marshalling objects into YAML has changed from 2 to 4 spaces.

## For change (1)

The functions `YamlDoc.Data()` and `YamlDoc.SetData()` are changed to work with `map[string]interface{}` instead of `map[interface{}]interface{}`.  

In addition, the function `YAmlDoc.Map()` is no longer needed to return a `map[string]interface{}` and has been removed.

## For change (2)

- New functions were added, `YamlDoc.BytesIndented()` and `YamlDoc.TextIndented()` that take a parameter for the indentation to use
- The existing funcs `YamlDoc.Bytes()` and `YamlDoc.Text()` generate YAML bytes/text with a default indentation of 2 spaces to keep it backward compatible.
- A bunch of testcases were updated to add the 2 space identation in order for the tests to be successful